### PR TITLE
Fix broken link in docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Automate code completions tailored to your codebase with IntelliCode Team completions
 
-[Visual Studio IntelliCode](https://marketplace.visualstudio.com/items?itemName=VisualStudioExptTeam.VSIntelliCode) saves you time by putting what you’re most likely to use at the top of your completion list. IntelliCode recommendations are based on thousands of open source projects on GitHub each with over 100 stars. When combined with the context of your code, the completion list is tailored to promote common practices. To get IntelliCode's starred completion suggestions for your own types, or other types not commonly found in open source, use [IntelliCode Team completions](https://aka.ms/vsic-teamcompletions-quickstart).
+[Visual Studio IntelliCode](https://docs.microsoft.com/en-us/visualstudio/intellicode/intellicode-visual-studio) saves you time by putting what you’re most likely to use at the top of your completion list. IntelliCode recommendations are based on thousands of open source projects on GitHub each with over 100 stars. When combined with the context of your code, the completion list is tailored to promote common practices. To get IntelliCode's starred completion suggestions for your own types, or other types not commonly found in open source, use [IntelliCode Team completions](https://aka.ms/vsic-teamcompletions-quickstart).
 
 With this GitHub Action, you can keep your Team completion suggestions up-to-date with your repository’s latest commit by automating the Team completions model training. 
 


### PR DESCRIPTION
The VS IntelliCode extension no longer exists in the marketplace because it now comes installed by default on VS 2022.
This will fix the broken link in docs to point towards: https://docs.microsoft.com/en-us/visualstudio/intellicode/intellicode-visual-studio